### PR TITLE
cleanup mklink tip for Windows 7

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This package provides an implementation of a debugger for Wolfram's _Mathematica
 	_Windows:_ Open cmd.exe *as administrator* (Open Start menu, search for cmd.exe, right click, select "Run as administrator")
 	```
 	$ cd <Some dir listed in your Mathematica $Path>
-	$ mklink /D . <path to where you cloned mathematica-debugger>\mathematica-debugger\Debugger
+	$ mklink /D Debugger <path to where you cloned mathematica-debugger>\mathematica-debugger\Debugger
 	```
 	
 3. Use ``Get["Debugger`"]`` or ``Needs["Debugger`"]`` to load the package in _Mathematica_


### PR DESCRIPTION
That `.` didn't quite work for me on Windows 7, but this is a cool looking tool!