### PR TITLE
Hotfix/fix to always return 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# ignore IntelliJ files
+.idea


### PR DESCRIPTION
Debugger: bugfix so we are not always return $Aborted when there is no message thrown