### PR TITLE
various improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# ignore IntelliJ files
+.idea

--- a/Debugger/Debugger.m
+++ b/Debugger/Debugger.m
@@ -12,7 +12,6 @@ ModuleNumbers;
 
 $DebuggerContexts = {"Global`"};
 
-debuggerEndLabel = "Debugger End "<>CreateUUID[];
 
 Begin["`Private`"];
 
@@ -24,6 +23,10 @@ Options[Debugger]:={
 	BreakOnAssert -> False,
 	ModuleNumbers -> False
 };
+
+(* label we use for Goto/Label for early abort *)
+debuggerEndLabel = "Debugger End "<>CreateUUID[];
+
 Debugger[codeBlock_,OptionsPattern[]]:=Module[
 	{runningReturn, reapReturn,return,sowedAssignments,sowedMessages},
 


### PR DESCRIPTION
Debugger: 
- always show all messages that are caught during evaluation, so one has an idea what the error is during debugging
- use Goto/Label instead of Abort[] to stop evaluation when there is message thrown so we always stop at exactly when the first message is thrown. B/c MM has this weird behavior that sometimes even though you abort, the evaluation still continues a few lines further, which is annoying and sometimes make debugging confusing
